### PR TITLE
add ifs again and fine-tuned error messages

### DIFF
--- a/ast.mli
+++ b/ast.mli
@@ -62,8 +62,19 @@ and sequence =
     SharedSequence of word list
   | Sequence of word list
 
+and if_body = IfBody of word * word
+
 and if_sform =
-    IfT of word * word
+    IfGEZ of if_body
+  | IfGZ of if_body
+  | IfLEZ of if_body
+  | IfLZ of if_body
+  | IfEmpty of if_body
+  | IfNonEmpty of if_body
+  | IfEZ of if_body
+  | IfNEZ of if_body
+  | IfT of if_body
+  | IfF of if_body
 
 and pattern = PatternAndMatch of word list * word
 and match_sform = PatternsAndMatches of pattern list

--- a/common.ml
+++ b/common.ml
@@ -71,7 +71,12 @@ and backquote_stringify a = P.sprintf "(bq-lit %s)"
      | BQBackquote(bq) -> backquote_stringify bq)
 
 and cs_stringify cs =
-  let pattern_stringify p =
+  let if_stringify s body =
+    match body with
+      IfBody(w1, w2) -> P.sprintf "%s { %s; %s }" s
+                          (word_stringify w1)
+                          (word_stringify w2)
+  in let pattern_stringify p =
        match p with
          PatternAndMatch(p, m) ->
          P.sprintf "pattern %s -> %s;"
@@ -80,9 +85,16 @@ and cs_stringify cs =
   in match cs with
     CtrlSeqIfForm(i) ->
     (match i with
-       IfT(w1, w2) -> P.sprintf "if-true { %s; %s }"
-                        (word_stringify w1)
-                        (word_stringify w2))
+       IfGEZ(ib) -> if_stringify "gez" ib
+     | IfGZ(ib) -> if_stringify "gz" ib
+     | IfLEZ(ib) -> if_stringify "lez" ib
+     | IfLZ(ib) -> if_stringify "lz" ib
+     | IfEmpty(ib) -> if_stringify "empty" ib
+     | IfNonEmpty(ib) -> if_stringify "non-empty" ib
+     | IfEZ(ib) -> if_stringify "ez" ib
+     | IfNEZ(ib) -> if_stringify "nez" ib
+     | IfT(ib) -> if_stringify "t" ib
+     | IfF(ib) -> if_stringify "f" ib)
   | CtrlSeqMatchForm(m) ->
     (match m with
        PatternsAndMatches(ps) -> String.concat "; "

--- a/docs/towel.grammar.def.tex
+++ b/docs/towel.grammar.def.tex
@@ -14,12 +14,14 @@
 
 Keywords in the Towel programming language is as follows:
 \begin{verbatim}
-ift match fun bind then
+if>=0 if>0 if<=0 if<0 if~0 if=0 ift iff ife ifne
+match function fun bind then
 \end{verbatim}
 
 The corresponding tokens are:
 \begin{verbatim}
-IFT MATCH FUNCTION BIND THEN
+IFGEZ IFGZ IFLEZ IFLZ IFNEZ IFEZ IFT IFF IFE IFNE
+MATCH FUNCTION FUNCTION BIND THEN
 \end{verbatim}
 
 \subsection{Punctuations}
@@ -161,7 +163,16 @@ Control sequences consists of \texttt{if} special forms and \texttt{match} speic
   control_sequence: if_sform
                   | match_sform
 
-  if_sform: IFT word COMMA word
+  if_sform: IFGEZ word COMMA word
+          | IFGZ word COMMA word
+          | IFLEZ word COMMA word
+          | IFLZ word COMMA word
+          | IFE word COMMA word
+          | IFNE word COMMA word
+          | IFEZ word COMMA word
+          | IFNEZ word COMMA word
+          | IFT word COMMA word
+          | IFF word COMMA word
 
   match_sform: MATCH (pattern SEMICOLON)* pattern
   (* e.g. "match pattern1, form1; pattern2, form2" *)

--- a/parser.mly
+++ b/parser.mly
@@ -8,7 +8,7 @@ let err s loc stofs eofs = raise (SyntacticError(s,
                                                  eofs));;
 %}
 
-%token IFT
+%token IFGEZ IFGZ IFLEZ IFLZ IFE IFNE IFEZ IFNEZ IFT IFF
 %token MATCH FUNCTION BIND THEN AT
 %token SLASH BQUOTE COMMA SEMICOLON
 %token LBRACKET RBRACKET LPAREN RPAREN LBRACE RBRACE
@@ -46,11 +46,11 @@ type_def:
   }
 | LPAREN error {
     err "expected names for type definition"
-      $startpos($2) $startofs($2) $endofs($2)
+      $startpos($2) $startofs($1) $endofs($2)
   }
 | LPAREN nonempty_list(name) error {
     err "expected a right parenthesis for type definition"
-    $startpos($3) $startofs($3) $endofs($3)
+    $startpos($3) $startofs($1) $endofs($3)
   }
 
 arg_def:
@@ -58,14 +58,135 @@ arg_def:
 | NAME type_def { ArgDefWithType($1, $2) }
 
 if_sform:
-| IFT word COMMA word { IfT($2, $4) }
+  IFGEZ word COMMA word { IfGEZ(IfBody($2, $4)) }
+| IFGZ word COMMA word { IfGZ(IfBody($2, $4)) }
+| IFLEZ word COMMA word { IfLEZ(IfBody($2, $4)) }
+| IFLZ word COMMA word { IfLZ(IfBody($2, $4)) }
+| IFE word COMMA word { IfEmpty(IfBody($2, $4)) }
+| IFNE word COMMA word { IfNonEmpty(IfBody($2, $4)) }
+| IFEZ word COMMA word { IfEZ(IfBody($2, $4)) }
+| IFNEZ word COMMA word { IfNEZ(IfBody($2, $4)) }
+| IFT word COMMA word { IfT(IfBody($2, $4)) }
+| IFF word COMMA word { IfF(IfBody($2, $4)) }
+| IFGEZ word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFGZ word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFLEZ word error {
+    err "expected a comma for else branch"    
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFLZ word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFE word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFNE word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFEZ word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFNEZ word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
 | IFT word error {
     err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFF word error {
+    err "expected a comma for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFGEZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFGZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFLEZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFLZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFEZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFNEZ word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFE word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFNE word COMMA error {
+    err "unexpected form for else branch"
     $startpos($3) $startofs($1) $endofs($3)
   }
 | IFT word COMMA error {
     err "unexpected form for else branch"
     $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFF word COMMA error {
+    err "unexpected form for else branch"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
+| IFGEZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFGZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFLEZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFLZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFE error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFNE error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFT error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFF error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFEZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
+  }
+| IFNEZ error {
+    err "unexpected form for if branch"
+    $startpos($2) $startofs($1) $endofs($2)
   }
 
 pattern:
@@ -153,7 +274,10 @@ word:
 sequence:
   LBRACE list(word) RBRACE { Sequence($2) }
 | LBRACE AT list(word) RBRACE { SharedSequence($3) }
-| LBRACE AT error { err "a" $startpos($3) $startofs($1) $endofs($3) }
+| LBRACE AT error {
+    err "expected a list of words for shared sequence"
+    $startpos($3) $startofs($1) $endofs($3)
+  }
 | LBRACE list(word) error {
     err "expected right parenthesis for sequence"
     $startpos($3) $startofs($1) $endofs($3)

--- a/scanner.mll
+++ b/scanner.mll
@@ -63,7 +63,16 @@ rule token = parse
 | _LBRACE { LBRACE }
 | _RBRACE { RBRACE }
 
+| "if>=0" { IFGEZ }
+| "if>0" { IFGZ }
+| "if<=0" { IFLEZ }
+| "if<0" { IFLZ }
+| "if=0" { IFEZ }
+| "if~0" { IFNEZ }
 | "ift" { IFT }
+| "iff" { IFF }
+| "ife" { IFE }
+| "ifne" { IFNE }
 | "match" { MATCH }
 | "bind" { BIND }
 | "then" { THEN }


### PR DESCRIPTION
The reason for more ifs is that you can write code like this, which is far more natural:

```
A B -
if>0 A,
if<0 B,
if=0 C
```

rather than

```
A B - 0 > ift A, {
A B - 0 < ift B, {
A B - 0 = ift C
}}
```
